### PR TITLE
Adding different incoming detection handling.

### DIFF
--- a/pe/__init__.py
+++ b/pe/__init__.py
@@ -1046,7 +1046,7 @@ class PacketEngine:
 
     def _frame_received_C(self, header, data):
         message = data.decode('utf-8')
-        incoming = (header.call_to in self._registered_callsigns)
+        incoming = message.startswith('*** CONNECTED To ')
         self._active_handler.connection_received(
             header.port, header.call_from, header.call_to, incoming, message)
 

--- a/pe/__init__.py
+++ b/pe/__init__.py
@@ -1046,7 +1046,7 @@ class PacketEngine:
 
     def _frame_received_C(self, header, data):
         message = data.decode('utf-8')
-        incoming = message.startswith('*** CONNECTED To ')
+        incoming = (header.call_to in self._registered_callsigns)
         self._active_handler.connection_received(
             header.port, header.call_from, header.call_to, incoming, message)
 


### PR DESCRIPTION
Closes #3


~~I'm not sure if this incoming connection detection logic is sufficient, but I feel like 99% of the time, a connection is going to be incoming if the call_to is one of the registered callsigns. This is the part of this change that I'm the most uncertain about;~~ the other changes should fix the issues assuming that the 'incoming' property is getting correctly set on the Connection objects that get created. (edited, since the change to __init__.py wasn't necessary.)

Thanks again for creating this fantastic project for me to play with!!