### PR TITLE
Fix handling of null-terminated callsigns

### DIFF
--- a/pe/__init__.py
+++ b/pe/__init__.py
@@ -1269,8 +1269,8 @@ class _Header:
         (port, data_kind, pid, call_from, call_to, data_len) = struct.unpack(
             _HDR_FMT, bytes)
         data_kind = chr(data_kind)
-        call_from = call_from.decode('utf-8', 'replace').rstrip('\0')
-        call_to = call_to.decode('utf-8', 'replace').rstrip('\0')
+        call_from = call_from.decode('utf-8', 'replace').split('\0')[0]
+        call_to = call_to.decode('utf-8', 'replace').split('\0')[0]
         return cls(port, data_kind, pid, call_from, call_to, data_len)
 
 


### PR DESCRIPTION
As per [the docs](https://www.on7lds.net/42/sites/default/files/AGWPEAPI.HTM#:~:text=CallFrom,above) (see also the linked footnote), `CallFrom` and `CallTo` are null-terminated strings which may contain garbage after the null byte.

When testing with Packet Engine Pro (basically just fancy AGWPE), I got random text following the callsigns (e.g. `CALL\x00ABCDE`). Splitting on null instead of just stripping it is the correct fix.

My guess is that whatever generator of AGWPE data you were testing with always starts with a nulled buffer, but this isn't the case for PE Pro or indeed guaranteed in the spec, which is why this worked for you.